### PR TITLE
fix: #6809 use _changes results last seq for since param

### DIFF
--- a/docs/_includes/api/replication.html
+++ b/docs/_includes/api/replication.html
@@ -32,7 +32,6 @@ All options default to `false` unless otherwise specified.
 * `options.batches_limit`: Number of batches to process at a time. Defaults to 10. This (along wtih `batch_size`) controls how many docs are kept in memory at a time, so the maximum docs in memory at once would equal `batch_size` &times; `batches_limit`.
 * `options.back_off_function`: backoff function to be used in `retry` replication. This is a function that takes the current backoff as input (or 0 the first time) and returns a new backoff in milliseconds. You can use this to tweak when and how replication will try to reconnect to a remote database when the user goes offline. Defaults to a function that chooses a random backoff between 0 and 2 seconds and doubles every time it fails to connect. The default delay will never exceed 10 minutes. (See [Customizing retry replication](#customizing-retry-replication) below.)
 * `options.checkpoint`: Can be used if you want to disable checkpoints on the source, target, or both. Setting this option to `false` will prevent writing checkpoints on both source and target. Setting it to `source` will only write checkpoints on the source. Setting it to `target` will only write checkpoints on the target.
-* `options.seq_interval`: Only available for http databases. Specifies that seq information only be generated every N changes. Larger values can improve changes throughput with CouchDB 2.0 and later. By default, Pouch will use seq_interval == batch size. Set to `false` to prevent passing seq_interval completely.
 
 #### Example Usage:
 

--- a/packages/node_modules/pouchdb-replication/src/replicate.js
+++ b/packages/node_modules/pouchdb-replication/src/replicate.js
@@ -28,7 +28,6 @@ function replicate(src, target, opts, returnValue, result) {
   var changedDocs = [];
   // Like couchdb, every replication gets a unique session id
   var session = uuid();
-  var seq_interval = opts.seq_interval;
 
   result = result || {
     ok: true,
@@ -324,7 +323,7 @@ function replicate(src, target, opts, returnValue, result) {
     // if no results were returned then we're done,
     // else fetch more
     if (changes.results.length > 0) {
-      changesOpts.since = changes.last_seq;
+      changesOpts.since = changes.results[changes.results.length - 1].seq;
       getChanges();
       processPendingBatch(true);
     } else {
@@ -420,9 +419,6 @@ function replicate(src, target, opts, returnValue, result) {
           selector: selector,
           return_docs: true // required so we know when we're done
         };
-        if (seq_interval !== false) {
-          changesOpts.seq_interval = seq_interval || batch_size;
-        }
         if (opts.filter) {
           if (typeof opts.filter !== 'string') {
             // required for the client-side filter in onChange

--- a/tests/integration/test.replication.js
+++ b/tests/integration/test.replication.js
@@ -4263,6 +4263,27 @@ adapters.forEach(function (adapters) {
       });
     });
 
+
+    it('#6809 doc_ids dont prevent one-shot replication', function () {
+
+      var db = new PouchDB(dbs.name);
+      var remote = new PouchDB(dbs.remote);
+
+      var writes = [];
+      for (var i = 0; i < 20; i++) {
+        writes.push(remote.put({_id: i + ''}));
+      }
+
+      return testUtils.Promise.all(writes).then(function () {
+        return db.replicate.from(remote, {batch_size: 1, doc_ids: ['11', '12', '13']});
+      }).then(function () {
+        return db.allDocs();
+      }).then(function (allDocs) {
+        allDocs.total_rows.should.equal(3);
+      });
+    });
+
+
     it('Replication filter using selector', function (done) {
       // only supported in CouchDB 2.x and later
       if (!testUtils.isCouchMaster()) {


### PR DESCRIPTION
CouchDB 2.X /db/_changes can return different last_seq numbers to the exact same request (https://github.com/apache/couchdb/issues/748).
When PouchDB uses _changes?since=last_seq for its argument on the next batch request, it sometimes misses documents.
This instead uses the last seq number in the results array.
Unfortunately that also means having to remove seq_interval as an option.